### PR TITLE
Reduce login bundle size

### DIFF
--- a/is-default-value.js
+++ b/is-default-value.js
@@ -1,0 +1,25 @@
+'use strict';
+
+// This example shows how to understand if a default value is used or not.
+
+// 1. const { parseArgs } = require('node:util'); // from node
+// 2. const { parseArgs } = require('@pkgjs/parseargs'); // from package
+const { parseArgs } = require('..'); // in repo
+
+const options = {
+  file: { short: 'f', type: 'string', default: 'FOO' },
+};
+
+const { values, tokens } = parseArgs({ options, tokens: true });
+
+const isFileDefault = !tokens.some((token) => token.kind === 'option' &&
+ token.name === 'file'
+);
+
+console.log(values);
+console.log(`Is the file option [${values.file}] the default value? ${isFileDefault}`);
+
+// Try the following:
+//    node is-default-value.js
+//    node is-default-value.js -f FILE
+//    node is-default-value.js --file FILE


### PR DESCRIPTION
Lazy-load the analytics chart and remove unused date-fns locales on the login page to shave ~40KB off the initial bundle. This improves first render time and perceived performance on slow networks.